### PR TITLE
Create a WCSBundle containing both astropy and galsim wcs

### DIFF
--- a/metacoadd/exposure.py
+++ b/metacoadd/exposure.py
@@ -1,5 +1,5 @@
 import copy
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import galsim
 import numpy as np
@@ -197,6 +197,40 @@ class Exposure:
         }
 
 
+class ExpList(list):
+    """Exposure list
+
+    List of Exposure.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def append(self, exp):
+        """append
+
+        Add a new Exposure to the list.
+
+        Args:
+            exp (metacoadd.Exposure): Exposure to add.
+        """
+
+        if not isinstance(exp, Exposure):
+            raise TypeError("exp must be a metacoadd.Exposure.")
+        super().append(exp)
+
+    def __setitem__(self, index, exp):
+        """[summary]
+
+        Args:
+            index ([type]): [description]
+            exp ([type]): [description]
+        """
+        if not isinstance(exp, Exposure):
+            raise TypeError("exp must be a metacoadd.Exposure.")
+        super().__setitem__(index, exp)
+
+
 class CoaddImage:
     """CoaddImage
 
@@ -245,7 +279,7 @@ class CoaddImage:
 
     def __init__(
         self,
-        explist: List[Exposure],
+        explist: ExpList,
         world_coadd_center: galsim.celestial.CelestialCoord,
         scale,
         image_coadd_size=None,
@@ -439,7 +473,7 @@ class CoaddImage:
         Args:
             relax_resize (float): Resize relax parameter.
         """
-        resized_explist = []
+        resized_explist = ExpList()
         for exp in self._orig_explist:
             resized_exp = self._resize_exp(exp, relax_resize)
             if resized_exp is not None:

--- a/metacoadd/exposure.py
+++ b/metacoadd/exposure.py
@@ -97,7 +97,7 @@ class Exposure:
         if set_meta:
             self._set_meta()
 
-    def __getitem__(self, bounds: galsim.BoundsI):
+    def __getitem__(self, bounds: galsim.BoundsI) -> "Exposure":
         """
         Return a new Exposure instance with the corresponding subimages.
         Also handle the WCS.

--- a/metacoadd/exposure.py
+++ b/metacoadd/exposure.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Optional, Self
+from typing import Optional, Union
 
 import galsim
 import numpy as np
@@ -72,8 +72,8 @@ class Exposure:
 
     def __init__(
         self,
-        image: np.ndarray | galsim.Image,
-        wcs: WCS | galsim.BaseWCS | WCSBundle,
+        image: Union[np.ndarray, galsim.Image],
+        wcs: Union[WCS, galsim.BaseWCS, WCSBundle],
         weight=None,
         flag=None,
         noise=None,
@@ -97,7 +97,7 @@ class Exposure:
         if set_meta:
             self._set_meta()
 
-    def __getitem__(self, bounds: galsim.BoundsI) -> Self:
+    def __getitem__(self, bounds: galsim.BoundsI):
         """
         Return a new Exposure instance with the corresponding subimages.
         Also handle the WCS.

--- a/metacoadd/exposure.py
+++ b/metacoadd/exposure.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 import galsim
 import numpy as np
@@ -245,7 +245,7 @@ class CoaddImage:
 
     def __init__(
         self,
-        explist: list[Exposure],
+        explist: List[Exposure],
         world_coadd_center: galsim.celestial.CelestialCoord,
         scale,
         image_coadd_size=None,

--- a/metacoadd/metacoadd.py
+++ b/metacoadd/metacoadd.py
@@ -184,7 +184,7 @@ class SimpleCoadd:
 
             # Check bounds, it should always pass. Just for safety.
             # We check only 'image' because it we always be there and the
-            # property are shared with the other knd.
+            # property are shared with the other kind.
             b = all_stamp["image"].bounds & self.coaddimage.image.bounds
             if b.isDefined():
                 if self._coadd_method == "weighted":

--- a/metacoadd/metacoadd.py
+++ b/metacoadd/metacoadd.py
@@ -184,7 +184,7 @@ class SimpleCoadd:
 
             # Check bounds, it should always pass. Just for safety.
             # We check only 'image' because it we always be there and the
-            # property are shared with the other kind.
+            # property are shared with the other knd.
             b = all_stamp["image"].bounds & self.coaddimage.image.bounds
             if b.isDefined():
                 if self._coadd_method == "weighted":
@@ -272,7 +272,7 @@ class SimpleCoadd:
 
         full_bounds = exp._meta["image_bounds"]
 
-        border_wcs = exp.wcs
+        border_wcs = exp.wcs_bundle.galsim
 
         border_image = galsim.Image(
             bounds=full_bounds,
@@ -300,7 +300,7 @@ class SimpleCoadd:
 
         input_reproj = (
             resized_border.image.array,
-            resized_border.wcs.astropy,
+            resized_border.wcs_bundle.astropy,
         )
         border_resamp, _ = self.coaddimage._do_resamp(
             input_reproj,
@@ -410,14 +410,14 @@ class MetaCoadd(SimpleCoadd):
             img_jac = ngmix.Jacobian(
                 row=self.coaddimage.image_coadd_center.x,
                 col=self.coaddimage.image_coadd_center.y,
-                wcs=self.coaddimage.coadd_wcs.jacobian(
+                wcs=self.coaddimage.coadd_wcs_bundle.galsim.jacobian(
                     world_pos=self.coaddimage.world_coadd_center
                 ),
             )
             psf_jac = ngmix.Jacobian(
                 row=self.psf_coaddimage.image_coadd_center.x,
                 col=self.psf_coaddimage.image_coadd_center.y,
-                wcs=self.psf_coaddimage.coadd_wcs.jacobian(
+                wcs=self.psf_coaddimage.coadd_wcs_bundle.galsim.jacobian(
                     world_pos=self.psf_coaddimage.world_coadd_center
                 ),
             )

--- a/metacoadd/metacoadd_ngmix_det.py
+++ b/metacoadd/metacoadd_ngmix_det.py
@@ -256,7 +256,7 @@ class SimpleCoadd:
 
         return stamp_dict
 
-    def _set_border(self, exp):
+    def _set_border(self, exp: Exposure):
         """Set border
 
         This method handle the CCD border to avoid issues in case the edge of
@@ -272,7 +272,7 @@ class SimpleCoadd:
 
         full_bounds = exp._meta["image_bounds"]
 
-        border_wcs = exp.wcs
+        border_wcs = exp.wcs_bundle.galsim
 
         border_image = galsim.Image(
             bounds=full_bounds,
@@ -300,7 +300,7 @@ class SimpleCoadd:
 
         input_reproj = (
             resized_border.image.array,
-            resized_border.wcs.astropy,
+            resized_border.wcs_bundle.astropy,
         )
         border_resamp, _ = self.coaddimage._do_resamp(
             input_reproj,
@@ -412,14 +412,14 @@ class MetaCoadd(SimpleCoadd):
             img_jac = ngmix.Jacobian(
                 row=self.coaddimage.image_coadd_center.x,
                 col=self.coaddimage.image_coadd_center.y,
-                wcs=self.coaddimage.coadd_wcs.jacobian(
+                wcs=self.coaddimage.coadd_wcs_bundle.galsim.jacobian(
                     world_pos=self.coaddimage.world_coadd_center
                 ),
             )
             psf_jac = ngmix.Jacobian(
                 row=self.psf_coaddimage.image_coadd_center.x,
                 col=self.psf_coaddimage.image_coadd_center.y,
-                wcs=self.psf_coaddimage.coadd_wcs.jacobian(
+                wcs=self.psf_coaddimage.coadd_wcs_bundle.galsim.jacobian(
                     world_pos=self.psf_coaddimage.world_coadd_center
                 ),
             )

--- a/metacoadd/simu.py
+++ b/metacoadd/simu.py
@@ -1,7 +1,7 @@
 import copy
 import os
 from math import ceil
-from typing import Optional
+from typing import List, Optional
 
 import galsim
 import metadetect as mdet
@@ -719,12 +719,12 @@ def run_simplecoadd(
 
 
 def run_metacoadd(
-    explist: list[Exposure],
+    explist: List[Exposure],
     coadd_ra,
     coadd_dec,
     coadd_scale,
     coadd_size,
-    explist_psf: Optional[list[Exposure]] = None,
+    explist_psf: Optional[List[Exposure]] = None,
 ):
     """Run metacoadd
 

--- a/metacoadd/simu.py
+++ b/metacoadd/simu.py
@@ -1,7 +1,7 @@
 import copy
 import os
 from math import ceil
-from typing import List, Optional
+from typing import Optional
 
 import galsim
 import metadetect as mdet
@@ -13,7 +13,7 @@ from astropy.wcs import WCS
 from metacoadd import utils
 
 # import metacoadd as mtc
-from metacoadd.exposure import CoaddImage, Exposure
+from metacoadd.exposure import CoaddImage, ExpList, Exposure
 from metacoadd.metacoadd import MetaCoadd, SimpleCoadd
 
 TEST_METADETECT_CONFIG = {
@@ -193,9 +193,9 @@ def make_sim(
 
     # Create exposures
     # print("Build all exposures..")
-    explist = []
+    explist = ExpList()
     if get_psf:
-        explist_psf = []
+        explist_psf = ExpList()
     for header_path in headers_list:
         params_single_tmp = params_single.copy()
         params_single_tmp["seed"] = np_rng.integers(low=1, high=2**30)
@@ -719,12 +719,12 @@ def run_simplecoadd(
 
 
 def run_metacoadd(
-    explist: List[Exposure],
+    explist: ExpList,
     coadd_ra,
     coadd_dec,
     coadd_scale,
     coadd_size,
-    explist_psf: Optional[List[Exposure]] = None,
+    explist_psf: Optional[ExpList] = None,
 ):
     """Run metacoadd
 

--- a/metacoadd/simu.py
+++ b/metacoadd/simu.py
@@ -1,17 +1,19 @@
 import copy
 import os
 from math import ceil
+from typing import Optional
 
 import galsim
 import metadetect as mdet
 import ngmix
 import numpy as np
 from astropy.io.fits import Header
+from astropy.wcs import WCS
 
 from metacoadd import utils
 
 # import metacoadd as mtc
-from metacoadd.exposure import CoaddImage, ExpList, Exposure
+from metacoadd.exposure import CoaddImage, Exposure
 from metacoadd.metacoadd import MetaCoadd, SimpleCoadd
 
 TEST_METADETECT_CONFIG = {
@@ -191,9 +193,9 @@ def make_sim(
 
     # Create exposures
     # print("Build all exposures..")
-    explist = ExpList()
+    explist = []
     if get_psf:
-        explist_psf = ExpList()
+        explist_psf = []
     for header_path in headers_list:
         params_single_tmp = params_single.copy()
         params_single_tmp["seed"] = np_rng.integers(low=1, high=2**30)
@@ -207,7 +209,7 @@ def make_sim(
             # print(f'{header_path} skipped.')
             continue
 
-        coadd_center_on_exp = exp_dict["wcs"].toImage(
+        coadd_center_on_exp = exp_dict["wcs"].galsim.toImage(
             galsim.CelestialCoord(
                 ra=coadd_ra * galsim.degrees,
                 dec=coadd_dec * galsim.degrees,
@@ -225,7 +227,7 @@ def make_sim(
                 nx=51,
                 ny=51,
                 offset=correct_offset,
-                wcs=psf_wcs,
+                wcs=psf_wcs.galsim,
             )
         except ValueError:
             psf_wcs = copy.deepcopy(exp_dict["wcs"])
@@ -233,7 +235,7 @@ def make_sim(
                 center=coadd_center_on_exp,
                 nx=51,
                 ny=51,
-                wcs=psf_wcs,
+                wcs=psf_wcs.galsim,
             )
 
         psf_weight = np.ones_like(psf_img_local.array) / 1e-5**2.0
@@ -417,7 +419,8 @@ def make_single_exp(
 
     # Get true WCS
     img_header = Header.fromfile(header_path)
-    wcs = galsim.AstropyWCS(header=img_header)
+    wcs_astropy = WCS(img_header)
+    wcs_bundle = utils.WCSBundle(wcs_astropy)
     nx = img_header["NAXIS1"]
     ny = img_header["NAXIS2"]
 
@@ -446,24 +449,24 @@ def make_single_exp(
     image = galsim.Image(
         nx,
         ny,
-        wcs=wcs,
+        wcs=wcs_bundle.galsim,
     )
     weight_image = galsim.Image(
         nx,
         ny,
-        wcs=wcs,
+        wcs=wcs_bundle.galsim,
     )
     # Used for the image
     _np_noise = np_rng.normal(size=(nx, ny)).T * params_single["noise"]
     _noise_image = galsim.Image(
         _np_noise,
-        wcs=wcs,
+        wcs=wcs_bundle.galsim,
     )
     # Independant noise for fixnoise
     np_noise = np_rng.normal(size=(nx, ny)).T * params_single["noise"]
     noise_image = galsim.Image(
         np_noise,
-        wcs=wcs,
+        wcs=wcs_bundle.galsim,
     )
 
     # Make PSF
@@ -489,14 +492,14 @@ def make_single_exp(
         "gal_img": final_img,
         "weight": weight_image.array,
         "noise": noise_image.array,
-        "wcs": wcs,
+        "wcs": wcs_bundle,
         "psf": psf,
     }
 
     return exp_dict
 
 
-def draw_obj(image, obj_dict, psf):
+def draw_obj(image: galsim.Image, obj_dict, psf):
     """Draw obj
 
     Draw all objects on a `galsim.Image`.
@@ -643,7 +646,7 @@ def run_simplecoadd(
     n_epoch = len(sim_data["band_data"]["i"])
 
     # Process images
-    explist = ExpList()
+    explist = []
     rng = np.random.RandomState(seed)
     for i in range(n_epoch):
         exp = Exposure(
@@ -672,7 +675,7 @@ def run_simplecoadd(
     output = (simplecoadd,)
 
     # Process PSFs
-    explist_psf = ExpList()
+    explist_psf = []
     for i in range(n_epoch):
         coadd_center_on_exp = sim_data["band_data"]["i"][i].wcs.toImage(
             sim_data["coadd_wcs"].center
@@ -716,12 +719,12 @@ def run_simplecoadd(
 
 
 def run_metacoadd(
-    explist,
+    explist: list[Exposure],
     coadd_ra,
     coadd_dec,
     coadd_scale,
     coadd_size,
-    explist_psf=None,
+    explist_psf: Optional[list[Exposure]] = None,
 ):
     """Run metacoadd
 

--- a/metacoadd/utils.py
+++ b/metacoadd/utils.py
@@ -1,25 +1,94 @@
-import copy
+from typing import Optional
 
+import astropy.wcs
 import galsim
 import ngmix
 import numpy as np
 
 
-def shift_wcs(wcs, offset):
-    # TODO: check inputs
+class WCSBundle:
+    _astropy_wcs: astropy.wcs.WCS
+    _galsim_WCS: galsim.BaseWCS
 
-    wcs_orig = copy.deepcopy(wcs)
-    if hasattr(wcs_orig, "astropy"):
-        ap_wcs = wcs_orig.astropy
-    elif hasattr(wcs_orig, "wcs"):
-        ap_wcs = wcs_orig.wcs
-    else:
-        raise ValueError(
-            "wcs must have an astropy component. Either .astropy or .wcs"
-        )
+    def __init__(
+        self,
+        wcs: astropy.wcs.WCS | galsim.BaseWCS,
+        image: Optional[np.ndarray | galsim.Image] = None,
+    ):
+        """Create a bundled wcs containing both astropy and galsim wcs.
+
+        The provided wcs can be either an astropy wcs or a galsim wcs.
+        If wcs is an astropy wcs: create a galsim.AstropyWCS (which is a
+        BaseWCS) and keep both.
+
+        If wcs is a galsim wcs:
+            - image must be given and be either an ndarray or a galsim Image
+            - the astropy wcs will be created from the galsim wcs and the image
+              bounds (either using image.bounds if galsim image or
+              BoundsI(1, 1 , nrow, ncol) if ndarray).
+
+        The wcs can be accessed with properties wcs_bundle.astropy or
+        wcs_bundle.galsim
+        """
+        if isinstance(wcs, astropy.wcs.WCS):
+            self._astropy_wcs = wcs
+            self._galsim_wcs = galsim.AstropyWCS(header=wcs.to_header())
+        elif isinstance(wcs, galsim.BaseWCS):
+            self._galsim_wcs = wcs
+            # in this case, we need the image
+            if isinstance(image, np.ndarray):
+                # we have no wcs in this image
+                xmin, ymin = 1, 1
+                nrow, ncol = image.shape
+                bounds = galsim.BoundsI(
+                    xmin, xmin + ncol - 1, ymin, ymin + nrow - 1
+                )
+                header = {}
+                wcs.writeToFitsHeader(header, bounds)
+                self._astropy_wcs = astropy.wcs.WCS(header)
+            elif isinstance(image, galsim.Image):
+                # There may be a wcs in this image, check they are compatible
+                if image.wcs is not None:
+                    reset_wcs = False
+                    if image.wcs != wcs:
+                        raise ValueError(
+                            "image wcs and provided wcs are different"
+                        )
+                else:
+                    reset_wcs = True
+                    image.wcs = wcs
+                header = {}
+                image.wcs.writeToFitsHeader(header, image.bounds)
+                self._astropy_wcs = astropy.wcs.WCS(header)
+                if reset_wcs:
+                    image.wcs = None
+            else:
+                raise ValueError(
+                    "missing image or wrong type, needed when giving galsim wcs"
+                )
+        else:
+            raise TypeError("wcs must be a galsim.BaseWVS or astropy.wcs.WCS")
+
+    @property
+    def galsim(self) -> galsim.BaseWCS:
+        return self._galsim_wcs
+
+    @property
+    def astropy(self) -> astropy.wcs.WCS:
+        return self._astropy_wcs
+
+
+def shift_wcs(wcs: WCSBundle, offset: galsim.PositionI) -> WCSBundle:
+    """Create a new WCSBundle by shifting the origin of the wcs by given
+    offset (the original wcs is not modified).
+    """
+    if not isinstance(wcs, WCSBundle):
+        raise TypeError(f"expected a WCSBundle for wcs, got {type(wcs)}")
+    if not isinstance(offset, galsim.PositionI):
+        raise TypeError(f"expected PositionI for offset, got {type(offset)}")
 
     # Get header
-    h = ap_wcs.to_header(relax=True)
+    h = wcs.astropy.to_header(relax=True)
     orig_crpix1 = h["CRPIX1"]
     orig_crpix2 = h["CRPIX2"]
 
@@ -30,9 +99,10 @@ def shift_wcs(wcs, offset):
     h["CRPIX1"] = new_crpix1
     h["CRPIX2"] = new_crpix2
 
-    new_wcs = galsim.AstropyWCS(header=h)
+    astropy_wcs = astropy.wcs.WCS(h)
+    wcs_bundle = WCSBundle(astropy_wcs)
 
-    return new_wcs
+    return wcs_bundle
 
 
 def exp2obs(exp, exp_psf=None, use_resamp=True):
@@ -57,7 +127,7 @@ def exp2obs(exp, exp_psf=None, use_resamp=True):
         noise = None
 
     # Set wcs
-    wcs = getattr(exp, "wcs" + kind)
+    wcs_bundle = getattr(exp, "wcs_bundle" + kind)
 
     if not isinstance(exp_psf, type(None)):
         if hasattr(exp_psf, "image" + kind):
@@ -70,14 +140,14 @@ def exp2obs(exp, exp_psf=None, use_resamp=True):
         else:
             pass
 
-        wcs_psf = getattr(exp_psf, "wcs" + kind)
+        wcs_bundle_psf = getattr(exp_psf, "wcs_bundle" + kind)
 
     dim = np.array(img.shape)
     cen = (dim - 1) / 2.0
     img_jac = ngmix.Jacobian(
         x=cen[0],
         y=cen[1],
-        wcs=wcs.jacobian(
+        wcs=wcs_bundle.galsim.jacobian(
             image_pos=galsim.PositionD(cen[0], cen[1]),
         ),
     )
@@ -88,7 +158,7 @@ def exp2obs(exp, exp_psf=None, use_resamp=True):
         psf_jac = ngmix.Jacobian(
             row=cen_psf[0],
             col=cen_psf[1],
-            wcs=wcs_psf.jacobian(
+            wcs=wcs_bundle_psf.galsim.jacobian(
                 image_pos=galsim.PositionD(cen_psf[0], cen_psf[1]),
             ),
         )

--- a/metacoadd/utils.py
+++ b/metacoadd/utils.py
@@ -8,7 +8,7 @@ import numpy as np
 
 class WCSBundle:
     _astropy_wcs: astropy.wcs.WCS
-    _galsim_WCS: galsim.BaseWCS
+    _galsim_wcs: galsim.BaseWCS
 
     def __init__(
         self,

--- a/metacoadd/utils.py
+++ b/metacoadd/utils.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Union
 
 import astropy.wcs
 import galsim
@@ -12,8 +12,8 @@ class WCSBundle:
 
     def __init__(
         self,
-        wcs: astropy.wcs.WCS | galsim.BaseWCS,
-        image: Optional[np.ndarray | galsim.Image] = None,
+        wcs: Union[astropy.wcs.WCS, galsim.BaseWCS],
+        image: Optional[Union[np.ndarray, galsim.Image]] = None,
     ):
         """Create a bundled wcs containing both astropy and galsim wcs.
 

--- a/test/basic_tests.py
+++ b/test/basic_tests.py
@@ -7,7 +7,7 @@ import numpy as np
 from astropy.io import fits
 from tqdm import tqdm
 
-from metacoadd.exposure import CoaddImage, ExpList, Exposure
+from metacoadd.exposure import CoaddImage, Exposure
 from metacoadd.metacoadd import SimpleCoadd
 
 # Defaults
@@ -377,7 +377,7 @@ exp_2 = Exposure(
 exp_3 = Exposure(
     image=exp_dict3["image"], wcs=exp_dict3["wcs"], weight=exp_dict3["weight"]
 )
-explist = ExpList()
+explist = []
 explist.append(exp_1)
 explist.append(exp_2)
 explist.append(exp_3)


### PR DESCRIPTION
Remove ExpList in favor of a normal list and check each element
*** test_basic.py still runs ***
However, that's a big change, as Exposure.wcs is now an Exposure.wcs_bundle: 
>>> Exposure.wcs => Exposure.wcs_bundle.galsim
>>> Exposure.wcs.astropy => Exposure.wcs_bundle.astropy

In the process, I saw the types are not well defined (attributes added to objects afterwards in various places). That would also need to be clarified.